### PR TITLE
Add handling for choice element

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,6 @@
 name: Building and Testing
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/testing/str-tests.xqm
+++ b/testing/str-tests.xqm
@@ -39,3 +39,18 @@ declare
     function st:test-escape-lucene-special-characters($str as xs:string) as xs:string {
         str:escape-lucene-special-characters($str)
 };
+
+declare 
+    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0"><space unit="chars" quantity="5"/>Wenn ich nicht an <hi rend="underline" n="1">Sie</hi> schriebe, meine gute liebe <persName key="A001069">Amalie</persName>, so würde ich mit Entschuldigungen über mein langes Stillschweigen anfangen.</p>', 'de') 
+    %test:assertEquals("Wenn ich nicht an ", "Sie", " schriebe, meine gute liebe ", "Amalie", ", so würde ich mit Entschuldigungen über mein langes Stillschweigen anfangen.")
+    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">nehmlich über jenes Stillschweigen <subst><del rend="overwritten">daß</del><add place="inline">das</add></subst> dem andern die Handgreiflichen Beweise versagt.</p>', 'de') 
+    %test:assertEquals("nehmlich über jenes Stillschweigen ", "das", " dem andern die Handgreiflichen Beweise versagt.")
+    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">testing <q>quotation</q> in text.</p>', 'de') 
+    %test:assertEquals("testing ", "„quotation“", " in text.")
+    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">testing choice with <choice><orig>orig</orig><reg>reg</reg></choice> in text.</p>', 'de') 
+    %test:assertEquals("testing choice with ", "reg", " in text.")
+    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">testing choice with <choice><sic>sic</sic><corr>corr</corr></choice> in text.</p>', 'de') 
+    %test:assertEquals("testing choice with ", "corr", " in text.")
+    function st:test-txtFromTEI($elem as element(), $lang as xs:string) as xs:string* {
+        str:txtFromTEI($elem, $lang)
+};

--- a/testing/str-tests.xqm
+++ b/testing/str-tests.xqm
@@ -53,8 +53,8 @@ declare
     %test:assertEquals("testing choice with ", "corr", " in text.")
     %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">te escribo en <choice><sic>Ingles</sic><corr>Inglés</corr></choice> <choice><sic>por que</sic><corr>porque</corr></choice> mi <choice><sic>Español</sic><corr>español</corr></choice> está demasiado limitado como vocabulario,</p>','de')
     %test:assertEquals("te escribo en ", "Inglés", " ", "porque", " mi ", "español", " está demasiado limitado como vocabulario,")
-    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">Dieser Text enthält ein <sic>einzlenes</sic> sic.</p>','de')
-    %test:assertEquals("Dieser Text enthält ein ", "einzlenes", " sic.")
+    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">Dieser Text enthält ein <sic>einzelnes</sic> sic.</p>','de')
+    %test:assertEquals("Dieser Text enthält ein ", "einzelnes", " sic.")
     function st:test-txtFromTEI($elem as element(), $lang as xs:string) as xs:string* {
         str:txtFromTEI($elem, $lang)
 };

--- a/testing/str-tests.xqm
+++ b/testing/str-tests.xqm
@@ -51,6 +51,10 @@ declare
     %test:assertEquals("testing choice with ", "reg", " in text.")
     %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">testing choice with <choice><sic>sic</sic><corr>corr</corr></choice> in text.</p>', 'de') 
     %test:assertEquals("testing choice with ", "corr", " in text.")
+    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">te escribo en <choice><sic>Ingles</sic><corr>Inglés</corr></choice> <choice><sic>por que</sic><corr>porque</corr></choice> mi <choice><sic>Español</sic><corr>español</corr></choice> está demasiado limitado como vocabulario,</p>','de')
+    %test:assertEquals("te escribo en ", "Inglés", " ", "porque", " mi ", "español", " está demasiado limitado como vocabulario,")
+    %test:args('<p xmlns="http://www.tei-c.org/ns/1.0">Dieser Text enthält ein <sic>einzlenes</sic> sic.</p>','de')
+    %test:assertEquals("Dieser Text enthält ein ", "einzlenes", " sic.")
     function st:test-txtFromTEI($elem as element(), $lang as xs:string) as xs:string* {
         str:txtFromTEI($elem, $lang)
 };

--- a/xquery/str.xqm
+++ b/xquery/str.xqm
@@ -147,7 +147,9 @@ declare function str:txtFromTEI($nodes as node()*, $lang as xs:string) as xs:str
         	if($node/@cert) then ($node/child::node() ! str:txtFromTEI(., $lang), '(?)') 
         	else $node/child::node() ! str:txtFromTEI(., $lang)
         case element(tei:del) return ()
+        case element(tei:orig) return ()
         case element(tei:subst) return $node/child::element() ! str:txtFromTEI(., $lang)
+        case element(tei:choice) return $node/child::element() ! str:txtFromTEI(., $lang)
         case element(tei:app) return ($node/tei:lem, $node/tei:rdg)[1] ! str:txtFromTEI(., $lang)
         case element(tei:note) return ()
         case element(tei:lb) return 

--- a/xquery/str.xqm
+++ b/xquery/str.xqm
@@ -148,6 +148,7 @@ declare function str:txtFromTEI($nodes as node()*, $lang as xs:string) as xs:str
         	else $node/child::node() ! str:txtFromTEI(., $lang)
         case element(tei:del) return ()
         case element(tei:orig) return ()
+        case element(tei:sic) return if($node/parent::tei:choice) then() else($node)
         case element(tei:subst) return $node/child::element() ! str:txtFromTEI(., $lang)
         case element(tei:choice) return $node/child::element() ! str:txtFromTEI(., $lang)
         case element(tei:app) return ($node/tei:lem, $node/tei:rdg)[1] ! str:txtFromTEI(., $lang)


### PR DESCRIPTION
The function str:txtFromTEI was not sensible for `<choice>` only for `<subst>`. This PR offers a simle extention for it.